### PR TITLE
Count \r and \t as whitespaces

### DIFF
--- a/crates/lexer/src/token_kind.rs
+++ b/crates/lexer/src/token_kind.rs
@@ -3,7 +3,7 @@ use std::fmt;
 
 #[derive(Debug, Copy, Clone, PartialEq, Logos)]
 pub enum TokenKind {
-    #[regex("[ \n]+")]
+    #[regex("[ \n\r\t]+")]
     Whitespace,
 
     #[token("fn")]


### PR DESCRIPTION
Otherwise produces Error tokens:
```
→ let x = 10
Root@0..12
  VariableDef@0..10
    LetKw@0..3 "let"
    Whitespace@3..4 " "
    Ident@4..5 "x"
    Whitespace@5..6 " "
    Equals@6..7 "="
    Whitespace@7..8 " "
    Literal@8..10
      Number@8..10 "10"
  Error@10..12
    Error@10..11 "\r"
    Whitespace@11..12 "\n"
error at 10..11: expected ‘+’, ‘-’, ‘*’, ‘/’, ‘let’, number, identifier, ‘-’ or ‘(’, but found an unrecognized token
[crates\eldiro\src\main.rs:27] root.stmts().filter_map(|stmt|
            if let ast::Stmt::VariableDef(var_def) = stmt {
                    Some(var_def.value())
                } else { None }).collect::<Vec<_>>() = [
    Some(
        Literal(
            Literal(
                Literal@8..10
                  Number@8..10 "10"
                ,
            ),
        ),
    ),
]
[crates\eldiro\src\main.rs:36] hir::lower(root) = (
    Database {
        exprs: Arena {
            len: 0,
            data: [],
        },
    },
    [
        VariableDef {
            name: "x",
            value: Literal {
                n: Some(
                    10,
                ),
            },
        },
    ],
)
```
This fixes the error and counts \t and \r as whitespaces:
`Whitespace@10..12 "\r\n"`